### PR TITLE
fix coalescing tcp packets

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -50,31 +50,42 @@ Bridge.prototype._handle_connection = function (socket) {
 }
 
 Bridge.prototype._handle_data = function (socket, rawData) {
-  debug('node --> bridge: %s', rawData)
+  var self = this
+
   try {
-    var message = JSON.parse(rawData)
+    var events = rawData.split('\0')
+
+    events.forEach(function (event) {
+      if (!event) {
+        return
+      }
+
+      debug('node --> bridge: %s', event)
+      var message = JSON.parse(event)
+
+      switch (_.get(message, 'method')) {
+        case IDENT:
+          self._handle_ident_message(socket, message)
+          break
+        case TELL:
+          self._handle_tell_message(socket, message)
+          break
+        case SHOUT:
+          self._handle_shout_message(socket, message)
+          break
+        case ACK:
+          self._handle_ack_message(socket, message)
+          break
+        case LEAVE:
+          self._handle_leave_message(socket, message)
+          break
+        default:
+          debug('received unrecognized command: %s', _.get(message, 'method'))
+      }
+    })
   } catch (e) {
     debug('bridge received invalid data, ignoring...')
     return
-  }
-  switch (_.get(message, 'method')) {
-    case IDENT:
-      this._handle_ident_message(socket, message)
-      break
-    case TELL:
-      this._handle_tell_message(socket, message)
-      break
-    case SHOUT:
-      this._handle_shout_message(socket, message)
-      break
-    case ACK:
-      this._handle_ack_message(socket, message)
-      break
-    case LEAVE:
-      this._handle_leave_message(socket, message)
-      break
-    default:
-      debug('received unrecognized command: %s', _.get(message, 'method'))
   }
 }
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -30,7 +30,7 @@ Message.prototype.toString = function () {
     out.nodeName = this.nodeName
   }
 
-  return JSON.stringify(out)
+  return JSON.stringify(out) + '\0'
 }
 
 module.exports = Message

--- a/lib/node.js
+++ b/lib/node.js
@@ -111,28 +111,37 @@ Node.prototype._handle_socket_error = function (e) {
 }
 
 Node.prototype._handle_data = function (rawData) {
-  debug('node <-- bridge: %s', rawData)
+  var self = this
 
   try {
-    var message = JSON.parse(rawData)
+    var events = rawData.toString().split('\0')
+
+    events.forEach(function (event) {
+      if (!event) {
+        return
+      }
+
+      debug('node <-- bridge: %s', event)
+      var message = JSON.parse(event)
+
+      switch (_.get(message, 'method')) {
+        case ACK:
+          self._handle_ack_message(message)
+          break
+        case TELL:
+          self._handle_tell_message(message)
+          break
+        case SHOUT:
+          self._handle_shout_message(message)
+          break
+        case CLOSE:
+          self._handle_close_message(message)
+          break
+      }
+    })
   } catch (e) {
     debug('node received invalid data, ignoring...')
     return
-  }
-
-  switch (_.get(message, 'method')) {
-    case ACK:
-      this._handle_ack_message(message)
-      break
-    case TELL:
-      this._handle_tell_message(message)
-      break
-    case SHOUT:
-      this._handle_shout_message(message)
-      break
-    case CLOSE:
-      this._handle_close_message(message)
-      break
   }
 }
 


### PR DESCRIPTION
When the pressure on the socket is high, there is not any guarantee
for one data event per packet. Indeed multiple json messages are
coalesced in one tcp packet.

We need to add a delimeter (an arbitrary '\0', compatible with C
strings, just in case) to separate the packets in valid json messages.

So we add the delimeter when the json message is stringified and we
parse the packet to split it finally in multiple json messages.

Fixes #20