### PR TITLE
add test for coalesced TCP packets

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -304,6 +304,25 @@ describe('Node', function () {
 
       goodNodes[2].shout('shout_eve', 'test-param')
     })
+
+    it('should catch events shouted very quickly', function (done) {
+      async.parallel([
+        function (done) {
+          goodNodes[0].on('shout_eve', function (param1) {
+            var isParamOk = param1 === 'test-param 1' ||
+              param1 === 'test-param 2' ||
+              param1 === 'test-param 3'
+
+            assert.ok(isParamOk)
+            done()
+          })
+        }
+      ], done)
+
+      goodNodes[2].shout('shout_eve', 'test-param 1')
+      goodNodes[2].shout('shout_eve', 'test-param 2')
+      goodNodes[2].shout('shout_eve', 'test-param 3')
+    })
   })
 
   describe('leave', function () {


### PR DESCRIPTION
This test is related to issue #20: json messages are coalesced in one
TCP packet and json parsing fails.

Indeed, before version 1.3.5, this test fails for timeout, because
the event listener is not triggered.

Fixed using a delimeter (see PR for details): the delimeter is added
when json message is stringified and then the message is splitted by
the delimeter when it is parsed.