### PR TITLE
encapsulate message delimiter

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -53,13 +53,9 @@ Bridge.prototype._handle_data = function (socket, rawData) {
   var self = this
 
   try {
-    var events = rawData.split('\0')
+    var events = Message.split(rawData)
 
     events.forEach(function (event) {
-      if (!event) {
-        return
-      }
-
       debug('node --> bridge: %s', event)
       var message = JSON.parse(event)
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -3,6 +3,8 @@
 var _ = require('lodash')
 var uuid = require('uuid')
 
+var DELIMITER = '\0'
+
 function Message (method, data) {
   this.id = uuid.v4()
   this.method = method
@@ -30,7 +32,15 @@ Message.prototype.toString = function () {
     out.nodeName = this.nodeName
   }
 
-  return JSON.stringify(out) + '\0'
+  return JSON.stringify(out) + DELIMITER
+}
+
+Message.split = function (rawData) {
+  var events = rawData.split(DELIMITER)
+
+  events.pop()
+
+  return events
 }
 
 module.exports = Message

--- a/lib/node.js
+++ b/lib/node.js
@@ -114,13 +114,9 @@ Node.prototype._handle_data = function (rawData) {
   var self = this
 
   try {
-    var events = rawData.toString().split('\0')
+    var events = Message.split(rawData.toString())
 
     events.forEach(function (event) {
-      if (!event) {
-        return
-      }
-
       debug('node <-- bridge: %s', event)
       var message = JSON.parse(event)
 


### PR DESCRIPTION
This refactoring allows to encapsulate the arbitrary delimter
character in Message code.

Message.split separates the json messages coalesced in the TCP packet.

Notice pop call removes the last empty string in the array due to the
trailing delimiter: "1,2,3,".split(",") // [ '1', '2', '3', '' ].

It avoids also to check if event is empty in the loop.