### PR TITLE
add socket error handler for the bridge

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -47,6 +47,7 @@ Bridge.prototype._handle_connection = function (socket) {
   socket.setEncoding('utf8')
   socket.setTimeout(0)
   socket.on('data', _.bind(this._handle_data, this, socket))
+  socket.on('error', _.bind(this._cleanup_dead_socket, this, socket))
 }
 
 Bridge.prototype._handle_data = function (socket, rawData) {


### PR DESCRIPTION
When a node disconnects, ECONNRESET exception is raised and
_cleanup_dead_socket method handles node leave.

Fixes #1